### PR TITLE
fix: use canonical header for default user agent

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -97,7 +98,7 @@ func prepareHeaders() error {
 				return fmt.Errorf("Invalid headers input: %v", headersInput)
 			}
 
-			Headers[strings.ToLower(keyValue[0])] = keyValue[1]
+			Headers[http.CanonicalHeaderKey(keyValue[0])] = keyValue[1]
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ var (
 	ClientConfig client.ClientConfig
 	Variables    = map[string]string{}
 	Headers      = map[string]string{
-		"user-agent": fmt.Sprintf("lac/%s", version),
+		"User-Agent": fmt.Sprintf("lac/%s", version),
 	}
 )
 

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -82,6 +82,6 @@ func True(t *testing.T, actual bool) {
 	t.Helper()
 
 	if !actual {
-		t.Errorf("expeted true")
+		t.Errorf("expected true")
 	}
 }

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -77,3 +77,11 @@ func StringContains(t *testing.T, value, expected string) {
 		t.Errorf("does not contain; got: %v; want to contain: %v", value, expected)
 	}
 }
+
+func True(t *testing.T, actual bool) {
+	t.Helper()
+
+	if !actual {
+		t.Errorf("expeted true")
+	}
+}

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -97,9 +97,10 @@ func NewRequest(data RequestData) Request {
 		method = http_method.NormalizeHttpMethod(data.Method)
 	}
 
-	headers := map[string]StringOrStringList{}
+	var headers map[string]StringOrStringList
 
 	if data.Headers != nil {
+		headers = map[string]StringOrStringList{}
 		for key, value := range data.Headers {
 			headers[http.CanonicalHeaderKey(key)] = value
 		}
@@ -109,7 +110,7 @@ func NewRequest(data RequestData) Request {
 		Method:  method,
 		Path:    data.Path,
 		Body:    data.Body,
-		Headers: data.Headers,
+		Headers: headers,
 	}
 }
 

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -97,6 +97,14 @@ func NewRequest(data RequestData) Request {
 		method = http_method.NormalizeHttpMethod(data.Method)
 	}
 
+	headers := map[string]StringOrStringList{}
+
+	if data.Headers != nil {
+		for key, value := range data.Headers {
+			headers[http.CanonicalHeaderKey(key)] = value
+		}
+	}
+
 	return Request{
 		Method:  method,
 		Path:    data.Path,

--- a/pkg/request/request_test.go
+++ b/pkg/request/request_test.go
@@ -14,7 +14,7 @@ func TestNewRequestDefaults(t *testing.T) {
 	assert.Equal(t, request.Path, "")
 	assert.Equal(t, request.Method, "GET")
 	assert.DeepEqual(t, request.Body, nil)
-	assert.DeepEqual(t, request.Headers, nil)
+	assert.True(t, request.Headers == nil)
 }
 
 func TestNewRequest(t *testing.T) {
@@ -29,6 +29,17 @@ func TestNewRequest(t *testing.T) {
 	assert.Equal(t, request.Method, http.MethodGet)
 	assert.DeepEqual(t, request.Body, data.Body)
 	assert.DeepEqual(t, request.Headers, data.Headers)
+}
+
+func TestNewRequestCanonicalHeaders(t *testing.T) {
+	data := RequestData{
+		Headers: map[string]StringOrStringList{
+			"canonical-header": []string{"value"},
+		},
+	}
+	request := NewRequest(data)
+	assert.Equal(t, len(request.Headers["Canonical-Header"]), 1)
+	assert.Equal(t, request.Headers["Canonical-Header"][0], "value")
 }
 
 func TestUnmarshalYaml(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated HTTP header naming conventions for improved consistency and compliance with industry standards.
  
- **New Features**
  - Introduced a new function to assist with assertions in testing.

- **Tests**
  - Modified existing tests for header handling and added a new test for verifying canonical header transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->