### PR TITLE
refactor: use any instead of interface{}

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ var (
 	PrintParameters          string
 
 	ClientConfig client.ClientConfig
-	Variables    = map[string]interface{}{}
+	Variables    = map[string]any{}
 	Headers      = map[string]string{
 		"User-Agent": fmt.Sprintf("lac/%s", version),
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,7 +14,7 @@ import (
 
 func runCommandFunction(
 	args []string,
-	variables map[string]interface{},
+	variables map[string]any,
 	headers map[string]string,
 	clientConfig *client.ClientConfig,
 ) {
@@ -43,7 +43,7 @@ func runCommandFunction(
 
 func runRequest(
 	req *request.Request,
-	variables map[string]interface{},
+	variables map[string]any,
 	headers map[string]string,
 	client *client.Client,
 	auth authentication.Auth,

--- a/pkg/param/param.go
+++ b/pkg/param/param.go
@@ -8,7 +8,7 @@ import (
 
 type Param string
 
-func (p Param) Resolve(replacements map[string]interface{}, useEnv bool) string {
+func (p Param) Resolve(replacements map[string]any, useEnv bool) string {
 	resolve := func(placeholder string, quoted bool) string {
 		if replacements != nil {
 			if value, ok := replacements[placeholder]; ok {

--- a/pkg/param/param_test.go
+++ b/pkg/param/param_test.go
@@ -55,7 +55,7 @@ func TestResolveWithoutEnv(t *testing.T) {
 
 func TestReplaceMultipleWithReplacements(t *testing.T) {
 	param := Param("${replacement_1}, ${replacement_2}!")
-	replacements := map[string]interface{}{
+	replacements := map[string]any{
 		"replacement_1": "Hello",
 		"replacement_2": "World",
 	}
@@ -68,7 +68,7 @@ func TestReplaceMultipleWithReplacements(t *testing.T) {
 func TestReplaceWithNumericValues(t *testing.T) {
 	param := Param("The answer is ${number} and I have ${float_num} dollars")
 
-	replacements := map[string]interface{}{
+	replacements := map[string]any{
 		"number":    42,
 		"float_num": 10.5,
 	}
@@ -81,7 +81,7 @@ func TestReplaceWithNumericValues(t *testing.T) {
 
 func TestReplaceWithBooleanValues(t *testing.T) {
 	param := Param("The statement is ${bool_value}")
-	replacements := map[string]interface{}{
+	replacements := map[string]any{
 		"bool_value": true,
 	}
 	expected := "The statement is true"
@@ -92,7 +92,7 @@ func TestReplaceWithBooleanValues(t *testing.T) {
 
 func TestReplaceWithNullValues(t *testing.T) {
 	param := Param("Is it ${null_value}")
-	replacements := map[string]interface{}{
+	replacements := map[string]any{
 		"null_value": nil,
 	}
 	expected := "Is it null"
@@ -103,7 +103,7 @@ func TestReplaceWithNullValues(t *testing.T) {
 
 func TestReplaceWithQuotedString(t *testing.T) {
 	param := Param(`"${value}"`)
-	replacements := map[string]interface{}{
+	replacements := map[string]any{
 		"value": "Hello, World",
 	}
 	expected := `"Hello, World"`

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -33,7 +33,7 @@ func (b *ByteBody) UnmarshalJSON(data []byte) error {
 }
 
 func (b *ByteBody) UnmarshalYAML(value *yaml.Node) error {
-	var raw interface{}
+	var raw any
 	if err := value.Decode(&raw); err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (s *StringOrStringList) UnmarshalJSON(data []byte) error {
 }
 
 func (s *StringOrStringList) UnmarshalYAML(value *yaml.Node) error {
-	var raw interface{}
+	var raw any
 	if err := value.Decode(&raw); err != nil {
 		return err
 	}

--- a/pkg/request/template.go
+++ b/pkg/request/template.go
@@ -28,7 +28,7 @@ func NewTemplate(templatePath string) (*Template, error) {
 	return &result, nil
 }
 
-func (t *Template) Interpolate(vars map[string]interface{}, useEnv bool) *Template {
+func (t *Template) Interpolate(vars map[string]any, useEnv bool) *Template {
 	result := Template(param.Param(*t).Resolve(vars, true))
 	return &result
 }

--- a/pkg/request/template_test.go
+++ b/pkg/request/template_test.go
@@ -107,7 +107,7 @@ func TestTemplate_Interpolate(t *testing.T) {
 		},
 	}
 
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		"string": "hello, world",
 		"number": 7,
 	}

--- a/pkg/utils/file_utils.go
+++ b/pkg/utils/file_utils.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func LoadItem(item string, dst interface{}) error {
+func LoadItem(item string, dst any) error {
 	var (
 		err  error
 		data *[]byte

--- a/pkg/utils/map_utils.go
+++ b/pkg/utils/map_utils.go
@@ -5,7 +5,7 @@ import (
 	"maps"
 )
 
-func FlattenMap(input map[string]interface{}, prefix string) map[string]string {
+func FlattenMap(input map[string]any, prefix string) map[string]string {
 	flattened := map[string]string{}
 
 	for key, value := range input {
@@ -17,11 +17,9 @@ func FlattenMap(input map[string]interface{}, prefix string) map[string]string {
 		}
 
 		switch child := value.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			submap := FlattenMap(child, newKey)
-			for k, v := range submap {
-				flattened[k] = v
-			}
+			maps.Copy(flattened, submap)
 		default:
 			flattened[newKey] = fmt.Sprintf("%v", value)
 		}

--- a/pkg/utils/map_utils_test.go
+++ b/pkg/utils/map_utils_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestFlattenMap(t *testing.T) {
-	m := map[string]interface{}{
-		"a": map[string]interface{}{
+	m := map[string]any{
+		"a": map[string]any{
 			"b": "c",
-			"d": map[string]interface{}{
+			"d": map[string]any{
 				"e": "f",
 			},
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal type declarations to a modern, more flexible alias, ensuring improved consistency and maintainability.
- **Tests**
	- Adjusted test cases to align with the updated type definitions, ensuring consistent behavior across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->